### PR TITLE
Allow non-http urls

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -1,6 +1,6 @@
 /*
  * Project: OpenURL
- * Version: 0.5.0
+ * Version: 0.5.1
  * Author:	EvilPenguin|
  *
  *

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -27,7 +27,7 @@
 %new
 - (NSDictionary *)openURLCommand:(NSString *)name withUserInfo:(NSDictionary *)userInfo {
     NSString *url = [userInfo objectForKey:@"url"];
-	if (![url hasPrefix:@"http://"]) url = [NSString stringWithFormat:@"http://%@", url];
+	if ([url rangeOfString:@"://"].location == NSNotFound) url = [NSString stringWithFormat:@"http://%@", url];
     [self applicationOpenURL:[NSURL URLWithString:url] publicURLsOnly:NO animating:YES];
 	return [NSDictionary dictionaryWithObject:[NSNumber numberWithInt:1] forKey:@"returnStatus"];
 }

--- a/layout/DEBIAN/control
+++ b/layout/DEBIAN/control
@@ -1,7 +1,7 @@
 Package: com.understruction.openurl
 Name: OpenURL
 Depends: mobilesubstrate
-Version: 0.5.0
+Version: 0.5.1
 Architecture: iphoneos-arm
 Description: Opens urls from the commandline
 Maintainer: EvilPenguin|

--- a/openurl.m
+++ b/openurl.m
@@ -1,6 +1,6 @@
 /*
  * Project: OpenURL
- * Version: 0.5.0
+ * Version: 0.5.1
  * Author:	EvilPenguin|
  *
  *


### PR DESCRIPTION
This patch only prepends http:// if no protocol was provided, so now cydia:, sms:, etc. links can be opened.
